### PR TITLE
Fix warning -Wfloat-conversion

### DIFF
--- a/sources/libcore/systemInformation.cpp
+++ b/sources/libcore/systemInformation.cpp
@@ -139,7 +139,7 @@ namespace cage
 		}
 
 		holder<processHandle> prg = newProcess(string("cat /proc/cpuinfo | grep -m 1 'cpu MHz' | cut -d: -f2-"));
-		return prg->readLine().trim().toFloat() * 1000000;
+		return numeric_cast<uint64>(prg->readLine().trim().toDouble() * 1e6);
 #else
 		// todo
 		return 0;


### PR DESCRIPTION
fixes warning: implicit conversion turns floating-point number into integer: 'float' to 'cage::uint64' (aka 'unsigned long') at systemInformation.cpp:142